### PR TITLE
Surface field-level errors in BuildiumError messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 ## [Unreleased]
 
+## [0.15.0] - 2026-04-06
+
+### Changed
+- `Buildium::BuildiumError` now inherits from `StandardError` so it can be
+  raised directly (`raise buildium_result if buildium_result.is_a?(Buildium::BuildiumError)`).
+- `BuildiumError#message` now combines the top-line `user_message` with the
+  field-level entries from the `Errors` array in the Buildium response. Previously
+  the field-level details were parsed into `#errors` but never surfaced when
+  consumers raised or logged `#error` alone, producing unhelpful messages like
+  `"The request failed validation. Update your request based on the validation
+  error message(s) and resubmit."`
+
+### Fixed
+- `@error_code` was being assigned to a misnamed `@error_message` ivar in the
+  initializer and was therefore unreadable through `attr_reader :error_code`.
+
 ## [0.1.0] - 2021-06-11
 
 - Initial release

--- a/lib/buildium/buildium_error.rb
+++ b/lib/buildium/buildium_error.rb
@@ -1,5 +1,5 @@
 module Buildium
-  class BuildiumError
+  class BuildiumError < StandardError
     attr_reader :error
     attr_reader :errors
     attr_reader :error_code
@@ -9,8 +9,26 @@ module Buildium
       data = parse_response(http_response)
       @error = data[:user_message]
       @errors = data[:errors]
-      @error_message = data[:error_code]
+      @error_code = data[:error_code]
       @response_code = http_response.response_code
+      super(build_message)
+    end
+
+    # Combines the top-line user_message with any field-level errors returned
+    # by Buildium so consumers see actionable detail when they `raise` or log
+    # the exception. Buildium validation responses look like:
+    #
+    #   { "UserMessage": "The request failed validation...",
+    #     "Errors": [{ "Message": "FirstName is required" }, ...] }
+    def build_message
+      details = Array(@errors).flat_map { |e| extract_error_text(e) }.reject { |s| s.nil? || s.empty? }
+      return @error.to_s if details.empty?
+
+      "#{@error} (#{details.join('; ')})"
+    end
+
+    def message
+      build_message
     end
 
     def default_response(response)
@@ -34,6 +52,23 @@ module Buildium
       return not_found_response(response) if response.response_code == 404
 
       default_response(response)
+    end
+
+    private
+
+    def extract_error_text(err)
+      case err
+      when Hash
+        # Buildium typically returns [{ message: "..." }] but be defensive
+        # in case the shape changes or includes a field name.
+        if err[:message]
+          [err[:field], err[:message]].compact.reject(&:empty?).join(': ')
+        else
+          err.values.compact.map(&:to_s).reject(&:empty?).join(': ')
+        end
+      else
+        err.to_s
+      end
     end
   end
 end

--- a/lib/buildium/version.rb
+++ b/lib/buildium/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Buildium
-  VERSION = '0.14.0'
+  VERSION = '0.15.0'
 end


### PR DESCRIPTION
Buildium API validation failures return both a generic UserMessage ("The request failed validation...") and an Errors array with the actual field-level details. The previous implementation parsed Errors into #errors but never surfaced it, so consumers that did `raise result.error` or logged `result.error` saw only the generic message and had no idea which field was invalid.

Changes:
- BuildiumError inherits from StandardError so it can be raised directly.
- BuildiumError#message combines user_message with the Errors array.
- Fix typo where @error_code was assigned to @error_message ivar, making attr_reader :error_code return nil.

Bumps to 0.15.0.